### PR TITLE
fix: remove duplicate conversions for relative path

### DIFF
--- a/src/transform/transformVuecli.ts
+++ b/src/transform/transformVuecli.ts
@@ -70,9 +70,6 @@ export class VueCliTransformer implements Transformer {
       const aliasOfChainWebpack = chainableConfig.resolve.alias.entries()
       const aliasOfConfigureWebpackObjectMode =
             vueConfig?.configureWebpack?.resolve?.alias || {}
-      Object.keys(aliasOfConfigureWebpackObjectMode).forEach((key) => {
-        aliasOfConfigureWebpackObjectMode[key] = `${rootDir}/${aliasOfConfigureWebpackObjectMode[key]}`
-      })
       const aliasOfConfigureFunctionMode = (() => {
         if (typeof vueConfig.configureWebpack === 'function') {
           let originConfig = chainableConfig.toConfig()


### PR DESCRIPTION
Added this section at the pull request #16 before. This problem has been resolved with 'path.resolve'.