### PR TITLE
docs: update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The following is a list of projects that successfully converted from a webpack p
 ### vue-cli
 - [vue-manage-system](https://github.com/lin-xin/vue-manage-system) -> [vue-manage-system-vite](https://github.com/originjs/webpack-to-vite-demos/tree/main/vue-manage-system-vite)
 - [newbee-mall-vue3-app](https://github.com/newbee-ltd/newbee-mall-vue3-app) -> [newbee-mall-vue3-app-vite](https://github.com/originjs/webpack-to-vite-demos/tree/main/newbee-mall-vue3-app-vite)
+- [vue-realworld-example-app](https://github.com/gothinkster/vue-realworld-example-app) -> [vue-realworld-example-app-vite](https://github.com/originjs/webpack-to-vite-demos/tree/main/vue-realworld-example-app-vite)
 
 ### webpack
 - [vue-uploader](https://github.com/simple-uploader/vue-uploader) -> [vue-uploader-vite](https://github.com/originjs/webpack-to-vite-demos/tree/main/vue-uploader-vite)


### PR DESCRIPTION
Add the project [vue-realworld-example-app](https://github.com/gothinkster/vue-realworld-example-app) which can be converted successfully using originjs/webpack-to-vite. 