### PR TITLE
fix: newline character causes compilation error

### DIFF
--- a/src/generate/render.ts
+++ b/src/generate/render.ts
@@ -104,6 +104,10 @@ export function serializeObject (val: unknown): string {
       return ret
     }
 
+    if (val.indexOf(newLine) !== -1) {
+      return `\`${val}\``
+    }
+
     return `'${val}'`
   }
 

--- a/tests/render.test.ts
+++ b/tests/render.test.ts
@@ -35,10 +35,10 @@ test('serialize string', () => {
         src`
   }
   const resultA = serializeObject(objA);
-  expect(resultA).toMatch('key1: \'\r\n \\src\'');
+  expect(resultA).toMatch('key1: \`\r\n \\src\`');
   expect(resultA).toMatch('key2: \'\'src\'\'');
   expect(resultA).toMatch('key3: \'"src"\'');
-  expect(resultA).toMatch('key4: \'newline\n');
+  expect(resultA).toMatch('key4: \`newline\n        src\`');
 });
 
 test('serializeObject', () => {


### PR DESCRIPTION
Newline character after sass/scss conversion causes compilation error, use template strings instead。