### PR TITLE
feat: printreport Sort by item.num

### DIFF
--- a/src/utils/report.ts
+++ b/src/utils/report.ts
@@ -28,10 +28,24 @@ function recordConver (args: ConverObj) {
   })
 }
 
+function _sortByNum (reportList: ConverObj[] = []) {
+  reportList.sort((current, next) => {
+    // same char, then sort by after-number
+    if (current.num[0] === next.num[0]) {
+      return +current.num.substring(1) - +next.num.substring(1)
+    }
+    // sort by first char
+    return current.num.charCodeAt(0) - next.num.charCodeAt(0)
+  })
+}
+
 function printReport (dir: string, beginTime: number) {
   cliInstance.update(cliInstance.total, { doSomething: 'All done!' });
   cliInstance.stop()
   console.log('conversion items successful converted:')
+
+  _sortByNum(reportList)
+
   reportList.forEach(item => {
     tabDt.push([item.num, item.feat, item.times?.toString()])
   })
@@ -58,4 +72,4 @@ function printReport (dir: string, beginTime: number) {
   logger.log(tableStr)
   console.log(chalk.green(`The report output path is ${dir}conversion.log`));
 }
-export { recordConver, printReport }
+export { recordConver, printReport, _sortByNum }

--- a/src/utils/report.ts
+++ b/src/utils/report.ts
@@ -72,4 +72,4 @@ function printReport (dir: string, beginTime: number) {
   logger.log(tableStr)
   console.log(chalk.green(`The report output path is ${dir}conversion.log`));
 }
-export { recordConver, printReport, _sortByNum }
+export { recordConver, printReport, sortByNum }

--- a/src/utils/report.ts
+++ b/src/utils/report.ts
@@ -28,7 +28,7 @@ function recordConver (args: ConverObj) {
   })
 }
 
-function _sortByNum (reportList: ConverObj[] = []) {
+function sortByNum (reportList: ConverObj[] = []) {
   reportList.sort((current, next) => {
     // same char, then sort by after-number
     if (current.num[0] === next.num[0]) {

--- a/src/utils/report.ts
+++ b/src/utils/report.ts
@@ -44,7 +44,7 @@ function printReport (dir: string, beginTime: number) {
   cliInstance.stop()
   console.log('conversion items successful converted:')
 
-  _sortByNum(reportList)
+  sortByNum(reportList)
 
   reportList.forEach(item => {
     tabDt.push([item.num, item.feat, item.times?.toString()])

--- a/src/utils/report.ts
+++ b/src/utils/report.ts
@@ -32,7 +32,7 @@ function _sortByNum (reportList: ConverObj[] = []) {
   reportList.sort((current, next) => {
     // same char, then sort by after-number
     if (current.num[0] === next.num[0]) {
-      return +current.num.substring(1) - +next.num.substring(1)
+      return Number(current.num.substring(1)) - Number(next.num.substring(1))
     }
     // sort by first char
     return current.num.charCodeAt(0) - next.num.charCodeAt(0)

--- a/tests/render.test.ts
+++ b/tests/render.test.ts
@@ -35,12 +35,10 @@ test('sort report by item.num', () => {
   const reportList: ConverObj[] = []
   const nums1 =  ["V06","B01","B04","V01"];
   const result1 = ["B01","B04","V01","V06"];
-  test1_nums.forEach((num) =>{
-    reportList.push({
-      num,
-      feat: ''
-    })
-  })
+  reportList = test1_nums.map(num => ({
+    num,
+    feat: ''
+  }))
   _sortByNum(reportList)
   expect(reportList.map(report => report.num)).toEqual(test1_sort)
 

--- a/tests/render.test.ts
+++ b/tests/render.test.ts
@@ -2,7 +2,7 @@ import path from "path";
 import {TemplateData} from "../src/config/config";
 import {render} from "../src/generate/render";
 import {readSync} from "../src/utils/file";
-import { _sortByNum } from "../src/utils/report"
+import { sortByNum } from "../src/utils/report"
 import fs from "fs";
 
 test('render vite.config.js from template',  () => {
@@ -39,7 +39,7 @@ test('sort report by item.num', () => {
     num,
     feat: ''
   }))
-  _sortByNum(reportList)
+  sortByNum(reportList)
   expect(reportList.map(report => report.num)).toEqual(test1_sort)
 
   // test 2 empty
@@ -52,6 +52,6 @@ test('sort report by item.num', () => {
       feat: ''
     })
   })
-  _sortByNum(reportList2)
+  sortByNum(reportList2)
   expect(reportList2.map(report => report.num)).toEqual(test2_sort)
 })

--- a/tests/render.test.ts
+++ b/tests/render.test.ts
@@ -32,26 +32,24 @@ test('sort report by item.num', () => {
     times?: number;// 'Conversion times'
   }
   // test 1, normal
-  const reportList: ConverObj[] = []
+  let reportList: ConverObj[] = []
   const nums1 =  ["V06","B01","B04","V01"];
   const result1 = ["B01","B04","V01","V06"];
-  reportList = test1_nums.map(num => ({
+  reportList = nums1.map(num => ({
     num,
     feat: ''
   }))
   sortByNum(reportList)
-  expect(reportList.map(report => report.num)).toEqual(test1_sort)
+  expect(reportList.map(report => report.num)).toEqual(result1)
 
   // test 2 empty
-  const reportList2: ConverObj[] = []
-  const test2_nums =  [];
-  const test2_sort = [];
-  test2_nums.forEach((num) =>{
-    reportList2.push({
-      num,
-      feat: ''
-    })
-  })
+  let reportList2: ConverObj[] = []
+  const nums2 =  [];
+  const result2 = [];
+  reportList2 = nums2.map(num => ({
+    num,
+    feat: ''
+  }))
   sortByNum(reportList2)
-  expect(reportList2.map(report => report.num)).toEqual(test2_sort)
+  expect(reportList2.map(report => report.num)).toEqual(result2)
 })

--- a/tests/render.test.ts
+++ b/tests/render.test.ts
@@ -33,8 +33,8 @@ test('sort report by item.num', () => {
   }
   // test 1, normal
   const reportList: ConverObj[] = []
-  const test1_nums =  ["V06","B01","B04","V01"];
-  const test1_sort = ["B01","B04","V01","V06"];
+  const nums1 =  ["V06","B01","B04","V01"];
+  const result1 = ["B01","B04","V01","V06"];
   test1_nums.forEach((num) =>{
     reportList.push({
       num,

--- a/tests/render.test.ts
+++ b/tests/render.test.ts
@@ -2,6 +2,7 @@ import path from "path";
 import {TemplateData} from "../src/config/config";
 import {render} from "../src/generate/render";
 import {readSync} from "../src/utils/file";
+import { _sortByNum } from "../src/utils/report"
 import fs from "fs";
 
 test('render vite.config.js from template',  () => {
@@ -23,3 +24,36 @@ test('render vite.config.js from template',  () => {
   expect(source).toMatch('viteCommonjs()')
   fs.rmdirSync(outDir, { recursive: true })
 });
+
+test('sort report by item.num', () => {
+  interface ConverObj {
+    num: string;// 'Number'
+    feat: string;// 'Conversion item'
+    times?: number;// 'Conversion times'
+  }
+  // test 1, normal
+  const reportList: ConverObj[] = []
+  const test1_nums =  ["V06","B01","B04","V01"];
+  const test1_sort = ["B01","B04","V01","V06"];
+  test1_nums.forEach((num) =>{
+    reportList.push({
+      num,
+      feat: ''
+    })
+  })
+  _sortByNum(reportList)
+  expect(reportList.map(report => report.num)).toEqual(test1_sort)
+
+  // test 2 empty
+  const reportList2: ConverObj[] = []
+  const test2_nums =  [];
+  const test2_sort = [];
+  test2_nums.forEach((num) =>{
+    reportList2.push({
+      num,
+      feat: ''
+    })
+  })
+  _sortByNum(reportList2)
+  expect(reportList2.map(report => report.num)).toEqual(test2_sort)
+})


### PR DESCRIPTION
### add sort feat to reportList inside printReport
```js
function printReport (dir: string, beginTime: number) {
  cliInstance.update(cliInstance.total, { doSomething: 'All done!' });
  cliInstance.stop()
  console.log('conversion items successful converted:')
  // sort feat
  _sortByNum(reportList)

  reportList.forEach(item => {
    tabDt.push([item.num, item.feat, item.times?.toString()])
  })
```

1. sort by item.num **first char**;
2. then, if first char **Equal**, sory by item.num after first char

## Test to vue-manage-system

- conversion.log

```
--------------------------------------------------
conversion items successful conversion: 

╔════════╤═══════════════════════════╤══════════════════╗
║ Number │ Conversion item           │ Conversion count ║
╟────────┼───────────────────────────┼──────────────────╢
║  B01   │ add package.json          │        1         ║
║  B02   │ add index.html            │        1         ║
║  B03   │ add vite.config.js        │        1         ║
║  B04   │ required plugins          │        1         ║
║  V01   │ base public path          │        1         ║
║  V02   │ css options               │        1         ║
║  V03   │ build options             │        1         ║
║  V05   │ resolve.alias options     │        1         ║
║  V06   │ client-side env variables │        1         ║
╚════════╧═══════════════════════════╧══════════════════╝
```